### PR TITLE
Add Track Create on Manifold Menu

### DIFF
--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/GfzMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/GfzMenuItems.cs
@@ -96,5 +96,25 @@ namespace Manifold.EditorTools.GC.GFZ
             }
         }
 
+        public static class TrackCreate
+        {
+            public const string Menu = Const.Menu.Manifold + "Track Create/";
+            public const string AddTrack = Menu + "Add Track";
+
+            public const string AddNormalRoad = Menu + "Road/";
+            public const string AddCircleRoad = Menu + "Cylinde or Pipe/";
+            public const string AddCapsuleRoad = Menu + "Capsule/";
+
+
+            public const string AddBezier = "Add Bezier";
+            public const string AddLine = "Add Line";
+            public const string AddSpiral = "Add Spiral";
+            public const string AddBezierOld = "Add Bezier (Legacy)"; // Legacy
+
+
+            public const string AddPropertyEmbed = Menu + "Add Property Embed";
+
+        }
+
     }
 }

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/GfzMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/GfzMenuItems.cs
@@ -115,8 +115,9 @@ namespace Manifold.EditorTools.GC.GFZ
             public const string AddTrack = Menu + "Add Track";
 
             public const string AddNormalRoad = Menu + "Road/";
-            public const string AddCylinderPipeRoad = Menu + "Cylinde or Pipe/";
+            public const string AddCylinderPipeRoad = Menu + "Pipe or Cylinde/";
             public const string AddCapsuleRoad = Menu + "Capsule/";
+            public const string AddOpenPipeCylinderRoad = Menu + "Pipe or Cylinder (Open)/";
 
 
             public const string AddBezier = "Add Bezier";

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/GfzMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/GfzMenuItems.cs
@@ -112,7 +112,7 @@ namespace Manifold.EditorTools.GC.GFZ
             public const string AddTrack = Menu + "Add Track";
 
             public const string AddNormalRoad = Menu + "Road/";
-            public const string AddCircleRoad = Menu + "Cylinde or Pipe/";
+            public const string AddCylinderPipeRoad = Menu + "Cylinde or Pipe/";
             public const string AddCapsuleRoad = Menu + "Capsule/";
 
 

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -28,16 +28,15 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
     public static class TrackCreateMenuItems
     {
         /// <summary>
-        /// Add GfzTrack Component
+        ///  Generate GfzTrack Component
         /// </summary>
         [MenuItem(GfzMenuItems.TrackCreate.AddTrack, priority = 1)]
-        public static void AddTrack()
+        public static void GenerateTrack()
         {
             GameObject track = new GameObject("Track");
             Undo.RegisterCreatedObjectUndo(track, "Add Track");
 
             Undo.AddComponent<GfzTrack>(track);
-            //track.AddComponent<GfzTrack>();
 
             return;
         }
@@ -104,10 +103,10 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
             {
                 track = GameObject.FindObjectOfType<GfzTrack>().gameObject;
             } catch(Exception e) {
-                string[] menuPaths = GfzMenuItems.TrackCreate.AddTrack.Split("/");
-                Debug.LogError($"GfzTrack object not exist.\r\nGenerate Track by {menuPaths[0]} > {menuPaths[1]} > {menuPaths[2]}");
-                Debug.Log(e.Message);
-                return;
+                Debug.LogWarning($"GfzTrack object not exist.\r\nAuto Generate Track");
+                Debug.Log($"Actual Exception: {e.Message}");
+                GenerateTrack();
+                track = GameObject.FindObjectOfType<GfzTrack>().gameObject;
             }
 
             // Generate GfzPathSegment GameObject
@@ -152,8 +151,8 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
             pathSegment.transform.parent = track.transform;
             Undo.RegisterCreatedObjectUndo(pathSegment, $"Generate {pathName}");
 
-            AddGfzShape(roadType, roadShape);
             AddGfzPath(pathType, pathSegment);
+            AddGfzShape(roadType, roadShape);
 
             return;
         }
@@ -200,19 +199,6 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
         public static void AddPathBezierOldCapsuleRoad() => GenerateGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CAPSULE);
 
-
-        [MenuItem(GfzMenuItems.TrackCreate.Menu + "Example/Create GameObject")]
-        static void CreateGameObject()
-        {
-            // Create GameObject hierarchy.
-            GameObject go = new GameObject("my GameObject");
-            GameObject child = new GameObject();
-            go.transform.position = new Vector3(5, 5, 5);
-            child.transform.parent = go.transform;
-
-            // Register root object for undo.
-            Undo.RegisterCreatedObjectUndo(go, "Create object");
-        }
 
     }
 }

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -85,12 +85,24 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
             switch (pathType)
             {
                 case GFZPathType.BEZIER_OLD:
-                    // Todo;
+                    GfzPathBezier bezier = obj.GetComponent<GfzPathBezier>();
+                    // ControlPoint0
+                    BezierPoint controlPoint = bezier.GetBezierPoint(0);
+                    controlPoint.position = matrix.Position();
+                    controlPoint.outTangent = matrix.Position() + (matrix.rotation * Vector3.forward * 100f);
+                    controlPoint.roll = matrix.RotationEuler().z;
+                    bezier.SetBezierPoint(0, controlPoint);
+                    // ControlPoint1
+                    controlPoint = bezier.GetBezierPoint(1);
+                    controlPoint.position = matrix.Position() + (matrix.rotation * Vector3.forward * CourseConst.GoodAverageLength);
+                    controlPoint.inTangent = matrix.Position() + (matrix.rotation * Vector3.forward * (CourseConst.GoodAverageLength - 100f));
+                    controlPoint.roll = matrix.RotationEuler().z;
+                    bezier.SetBezierPoint(1, controlPoint);
                     break;
                 case GFZPathType.BEZIER:
                     Undo.RecordObject(obj, $"Change FixedBezier {obj.name}");
-                    GfzPathFixedBezier bezier = obj.GetComponent<GfzPathFixedBezier>();
-                    bezier.SetControlPoints(matrix.Position(), matrix.rotation);
+                    GfzPathFixedBezier fixedBezier = obj.GetComponent<GfzPathFixedBezier>();
+                    fixedBezier.SetControlPoints(matrix.Position(), matrix.rotation);
                     break;
                 case GFZPathType.LINE:
                 case GFZPathType.SPIRAL:

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -25,14 +25,6 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         Capsule
     }
 
-    public enum GFZPropertyEmbedType
-    {
-        Recover,
-        Slip,
-        Dirt,
-        Lava
-    }
-
     public static class TrackCreateMenuItems
     {
         const string NamePathBezier = "bezier";

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -27,8 +27,16 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
 
     public static class TrackCreateMenuItems
     {
+        const string NamePathBezier = "bezier";
+        const string NamePathLine = "line";
+        const string NamePathSpiral = "spiral";
+
+        const string NameRoadNormal = "road";
+        const string NameRoadCylindePipe = "circle";
+        const string NameRoadCupsule = "capsule";
+
         /// <summary>
-        ///  Generate GfzTrack Component
+        ///  Generate GfzTrack component
         /// </summary>
         [MenuItem(GfzMenuItems.TrackCreate.AddTrack, priority = 1)]
         public static void GenerateTrack()
@@ -42,7 +50,7 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         }
 
         /// <summary>
-        /// Add GfzPathSegment extended Component
+        /// Add GfzPathSegment extended component
         /// </summary>
         /// <param name="pathType"></param>
         /// <param name="obj"></param>
@@ -68,7 +76,7 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         }
 
         /// <summary>
-        /// Aling to Previous Generated PathSegment
+        /// Aling to previous Generated PathSegment
         /// </summary>
         /// <param name="pathType"></param>
         /// <param name="track"></param>
@@ -174,17 +182,17 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
                     GfzPathFixedBezier[] gfzPathFixedBeziers = GameObject.FindObjectsOfType<GfzPathFixedBezier>();
                     GfzPathBezier[] gfzPathBeziers = GameObject.FindObjectsOfType<GfzPathBezier>();
                     idx = gfzPathFixedBeziers.Length + gfzPathBeziers.Length;
-                    pathName = $"bezier ({idx})";
+                    pathName = $"{NamePathBezier} ({idx})";
                     break;
                 case GFZPathType.LINE:
                     GfzPathLine[] gfzPathLines = GameObject.FindObjectsOfType<GfzPathLine>();
                     idx = gfzPathLines.Length;
-                    pathName = $"line ({idx})";
+                    pathName = $"{NamePathLine} ({idx})";
                     break;
                 case GFZPathType.SPIRAL:
                     GfzPathSpiral[] gfzPathSpirals = GameObject.FindObjectsOfType<GfzPathSpiral>();
                     idx = gfzPathSpirals.Length;
-                    pathName = $"spiral ({idx})";
+                    pathName = $"{NamePathSpiral} ({idx})";
                     break;
             }
             GameObject pathSegment = new GameObject(pathName);
@@ -193,13 +201,13 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
             switch (roadType)
             {
                 case GFZRoadType.NORMAL:
-                    roadName = "road";
+                    roadName = NameRoadNormal;
                     break;
                 case GFZRoadType.CIRCLE:
-                    roadName = "circle";
+                    roadName = NameRoadCylindePipe;
                     break;
                 case GFZRoadType.CAPSULE:
-                    roadName = "capsule";
+                    roadName = NameRoadCupsule;
                     break;
             }
             GameObject roadShape = new GameObject(roadName);

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -28,59 +28,74 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
     public static class TrackCreateMenuItems
     {
         /// <summary>
-        /// Add GfzTrack Component.
+        /// Add GfzTrack Component
         /// </summary>
         [MenuItem(GfzMenuItems.TrackCreate.AddTrack, priority = 1)]
         public static void AddTrack()
         {
             GameObject track = new GameObject("Track");
-            //Undo.RegisterCreatedObjectUndo(track, "Add Track");
+            Undo.RegisterCreatedObjectUndo(track, "Add Track");
 
-            track.AddComponent<GfzTrack>();
+            Undo.AddComponent<GfzTrack>(track);
+            //track.AddComponent<GfzTrack>();
 
             return;
         }
 
-        // Add GfzShape Component as child.
-        public static void AddGfzShape(Transform parent, GFZRoadType roadType)
+        /// <summary>
+        /// Add GfzShape Component
+        /// </summary>
+        /// <param name="roadType"></param>
+        /// <param name="obj"></param>
+        public static void AddGfzShape(GFZRoadType roadType, GameObject obj)
         {
-            string objName = "";
             switch (roadType)
             {
                 case GFZRoadType.NORMAL:
-                    objName = "road";
+                    Undo.AddComponent<GfzShapeRoad>(obj);
                     break;
                 case GFZRoadType.CIRCLE:
-                    objName = "circle";
+                    Undo.AddComponent<GfzShapePipeCylinder>(obj);
                     break;
                 case GFZRoadType.CAPSULE:
-                    objName = "capsule";
-                    break;
-            }
-
-            GameObject obj = new GameObject(objName);
-            //Undo.RegisterCreatedObjectUndo(obj, $"Add {objName}");
-            //EditorUtility.SetDirty(obj);
-
-            obj.transform.parent = parent;
-
-            switch (roadType)
-            {
-                case GFZRoadType.NORMAL:
-                    obj.AddComponent<GfzShapeRoad>();
-                    break;
-                case GFZRoadType.CIRCLE:
-                    obj.AddComponent<GfzShapePipeCylinder>();
-                    break;
-                case GFZRoadType.CAPSULE:
-                    obj.AddComponent<GfzShapeCapsule>();
+                    Undo.AddComponent<GfzShapeCapsule>(obj);
                     break;
             }
 
         }
 
-        // Add GfzPathSegment Extended Component as child.
-        public static void AddGfzPath(GFZPathType pathType, GFZRoadType roadType)
+        /// <summary>
+        /// Add GfzPathSegment extended Component
+        /// </summary>
+        /// <param name="pathType"></param>
+        /// <param name="obj"></param>
+        public static void AddGfzPath(GFZPathType pathType, GameObject obj)
+        {
+            switch (pathType)
+            {
+                case GFZPathType.BEZIER_OLD:
+                    Undo.AddComponent<GfzPathBezier>(obj);
+                    break;
+                case GFZPathType.BEZIER:
+                    Undo.AddComponent<GfzPathFixedBezier>(obj);
+                    break;
+                case GFZPathType.LINE:
+                    Undo.AddComponent<GfzPathLine>(obj);
+                    break;
+                case GFZPathType.SPIRAL:
+                    Undo.AddComponent<GfzPathSpiral>(obj);
+                    break;
+            }
+
+            return;
+        }
+
+        /// <summary>
+        /// Generate GfzPathSegment Extended Component as child
+        /// </summary>
+        /// <param name="pathType"></param>
+        /// <param name="roadType"></param>
+        public static void GenerateGfzPath(GFZPathType pathType, GFZRoadType roadType)
         {
             int idx = -1;
             GameObject track;
@@ -95,8 +110,8 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
                 return;
             }
 
-
-            string objName = "";
+            // Generate GfzPathSegment GameObject
+            string pathName = "";
             switch (pathType)
             {
                 case GFZPathType.BEZIER_OLD:
@@ -104,94 +119,100 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
                     GfzPathFixedBezier[] gfzPathFixedBeziers = GameObject.FindObjectsOfType<GfzPathFixedBezier>();
                     GfzPathBezier[] gfzPathBeziers = GameObject.FindObjectsOfType<GfzPathBezier>();
                     idx = gfzPathFixedBeziers.Length + gfzPathBeziers.Length;
-                    objName = $"bezier ({idx})";
+                    pathName = $"bezier ({idx})";
                     break;
                 case GFZPathType.LINE:
                     GfzPathLine[] gfzPathLines = GameObject.FindObjectsOfType<GfzPathLine>();
                     idx = gfzPathLines.Length;
-                    objName = $"ilne ({idx})";
+                    pathName = $"ilne ({idx})";
                     break;
                 case GFZPathType.SPIRAL:
                     GfzPathSpiral[] gfzPathSpirals = GameObject.FindObjectsOfType<GfzPathSpiral>();
                     idx = gfzPathSpirals.Length;
-                    objName = $"spiral ({idx})";
+                    pathName = $"spiral ({idx})";
                     break;
             }
+            GameObject pathSegment = new GameObject(pathName);
 
-
-            GameObject obj = new GameObject(objName);
-            //Undo.RegisterCreatedObjectUndo(obj, $"Add Path");
-            //EditorUtility.SetDirty(obj);
-
-            //Undo.RecordObject(track, $"set {objName} as child of Track");
-            obj.transform.parent = track.transform;
-            //EditorUtility.SetDirty(track);
-
-            //Undo.RecordObject(track, $"AddComponent {pathType}");
-            switch (pathType)
+            string roadName = "";
+            switch (roadType)
             {
-                case GFZPathType.BEZIER_OLD:
-                    obj.AddComponent<GfzPathBezier>();
+                case GFZRoadType.NORMAL:
+                    roadName = "road";
                     break;
-                case GFZPathType.BEZIER:
-                    obj.AddComponent<GfzPathFixedBezier>();
+                case GFZRoadType.CIRCLE:
+                    roadName = "circle";
                     break;
-                case GFZPathType.LINE:
-                    obj.AddComponent<GfzPathLine>();
-                    break;
-                case GFZPathType.SPIRAL:
-                    obj.AddComponent<GfzPathSpiral>();
+                case GFZRoadType.CAPSULE:
+                    roadName = "capsule";
                     break;
             }
+            GameObject roadShape = new GameObject(roadName);
+            roadShape.transform.parent = pathSegment.transform;
+            pathSegment.transform.parent = track.transform;
+            Undo.RegisterCreatedObjectUndo(pathSegment, $"Generate {pathName}");
 
-
-            AddGfzShape(obj.transform, roadType);
-
-            //EditorUtility.SetDirty(track);
+            AddGfzShape(roadType, roadShape);
+            AddGfzPath(pathType, pathSegment);
 
             return;
         }
 
+
         // Normal Road
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
-        public static void AddPathBezierNormalRoad() => AddGfzPath(GFZPathType.BEZIER, GFZRoadType.NORMAL);
+        public static void AddPathBezierNormalRoad() => GenerateGfzPath(GFZPathType.BEZIER, GFZRoadType.NORMAL);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
-        public static void AddPathLineNormalRoad() => AddGfzPath(GFZPathType.LINE, GFZRoadType.NORMAL);
+        public static void AddPathLineNormalRoad() => GenerateGfzPath(GFZPathType.LINE, GFZRoadType.NORMAL);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
-        public static void AddPathSprialNormalRoad() => AddGfzPath(GFZPathType.SPIRAL, GFZRoadType.NORMAL);
+        public static void AddPathSprialNormalRoad() => GenerateGfzPath(GFZPathType.SPIRAL, GFZRoadType.NORMAL);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
-        public static void AddPathBezierOldNormalRoad() => AddGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.NORMAL);
+        public static void AddPathBezierOldNormalRoad() => GenerateGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.NORMAL);
 
 
         // Circle Road
         [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
-        public static void AddPathBezierCircleRoad() => AddGfzPath(GFZPathType.BEZIER, GFZRoadType.CIRCLE);
+        public static void AddPathBezierCircleRoad() => GenerateGfzPath(GFZPathType.BEZIER, GFZRoadType.CIRCLE);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
-        public static void AddPathLineCircleRoad() => AddGfzPath(GFZPathType.LINE, GFZRoadType.CIRCLE);
+        public static void AddPathLineCircleRoad() => GenerateGfzPath(GFZPathType.LINE, GFZRoadType.CIRCLE);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
-        public static void AddPathSprialCircleRoad() => AddGfzPath(GFZPathType.SPIRAL, GFZRoadType.CIRCLE);
+        public static void AddPathSprialCircleRoad() => GenerateGfzPath(GFZPathType.SPIRAL, GFZRoadType.CIRCLE);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
-        public static void AddPathBezierOldCircleRoad() => AddGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CIRCLE);
+        public static void AddPathBezierOldCircleRoad() => GenerateGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CIRCLE);
 
 
         // Capsule Road
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
-        public static void AddPathBezierCapsuleRoad() => AddGfzPath(GFZPathType.BEZIER, GFZRoadType.CAPSULE);
+        public static void AddPathBezierCapsuleRoad() => GenerateGfzPath(GFZPathType.BEZIER, GFZRoadType.CAPSULE);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
-        public static void AddPathLineCapsuleRoad() => AddGfzPath(GFZPathType.LINE, GFZRoadType.CAPSULE);
+        public static void AddPathLineCapsuleRoad() => GenerateGfzPath(GFZPathType.LINE, GFZRoadType.CAPSULE);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
-        public static void AddPathSprialCapsuleRoad() => AddGfzPath(GFZPathType.SPIRAL, GFZRoadType.CAPSULE);
+        public static void AddPathSprialCapsuleRoad() => GenerateGfzPath(GFZPathType.SPIRAL, GFZRoadType.CAPSULE);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
-        public static void AddPathBezierOldCapsuleRoad() => AddGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CAPSULE);
+        public static void AddPathBezierOldCapsuleRoad() => GenerateGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CAPSULE);
+
+
+        [MenuItem(GfzMenuItems.TrackCreate.Menu + "Example/Create GameObject")]
+        static void CreateGameObject()
+        {
+            // Create GameObject hierarchy.
+            GameObject go = new GameObject("my GameObject");
+            GameObject child = new GameObject();
+            go.transform.position = new Vector3(5, 5, 5);
+            child.transform.parent = go.transform;
+
+            // Register root object for undo.
+            Undo.RegisterCreatedObjectUndo(go, "Create object");
+        }
 
     }
 }

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -1,5 +1,6 @@
 ﻿using GameCube.GFZ.TPL;
 using Manifold.IO;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -26,9 +27,8 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
 
     public static class TrackCreateMenuItems
     {
-
         /// <summary>
-        /// Add GfzTrack Component as child.
+        /// Add GfzTrack Component.
         /// </summary>
         [MenuItem(GfzMenuItems.TrackCreate.AddTrack, priority = 1)]
         public static void AddTrack()
@@ -79,15 +79,19 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
 
         }
 
-        // Add GfzPathSegment Component as child.
+        // Add GfzPathSegment Extended Component as child.
         public static void AddGfzPath(GFZPathType pathType, GFZRoadType roadType)
         {
-            int idx = -1; // TODO: GET index
+            int idx = -1;
+            GameObject track;
 
-            GameObject track = GameObject.FindObjectOfType<GfzTrack>().gameObject;
-
-            if (track == null)
+            try
             {
+                track = GameObject.FindObjectOfType<GfzTrack>().gameObject;
+            } catch(Exception e) {
+                string[] menuPaths = GfzMenuItems.TrackCreate.AddTrack.Split("/");
+                Debug.LogError($"GfzTrack object not exist.\r\nGenerate Track by {menuPaths[0]} > {menuPaths[1]} > {menuPaths[2]}");
+                Debug.Log(e.Message);
                 return;
             }
 

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -10,19 +10,27 @@ using UnityEngine;
 
 namespace Manifold.EditorTools.GC.GFZ.Stage.Track
 {
-    public enum GFZPathType
+    public enum PathType
     {
-        BEZIER_OLD,
-        BEZIER,
-        LINE,
-        SPIRAL
+        BezierOld,
+        Bezier,
+        Line,
+        Spiral
     }
 
-    public enum GFZRoadType
+    public enum RoadType
     {
-        NORMAL,
-        CIRCLE,
-        CAPSULE
+        Normal,
+        CylinderPipe,
+        Capsule
+    }
+
+    public enum GFZPropertyEmbedType
+    {
+        Recover,
+        Slip,
+        Dirt,
+        Lava
     }
 
     public static class TrackCreateMenuItems
@@ -54,20 +62,20 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         /// </summary>
         /// <param name="pathType"></param>
         /// <param name="obj"></param>
-        public static void AddGfzPath(GFZPathType pathType, GameObject obj)
+        public static void AddGfzPath(PathType pathType, GameObject obj)
         {
             switch (pathType)
             {
-                case GFZPathType.BEZIER_OLD:
+                case PathType.BezierOld:
                     Undo.AddComponent<GfzPathBezier>(obj);
                     break;
-                case GFZPathType.BEZIER:
+                case PathType.Bezier:
                     Undo.AddComponent<GfzPathFixedBezier>(obj);
                     break;
-                case GFZPathType.LINE:
+                case PathType.Line:
                     Undo.AddComponent<GfzPathLine>(obj);
                     break;
-                case GFZPathType.SPIRAL:
+                case PathType.Spiral:
                     Undo.AddComponent<GfzPathSpiral>(obj);
                     break;
             }
@@ -76,12 +84,12 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         }
 
         /// <summary>
-        /// Aling to previous Generated PathSegment
+        /// Aling to previous generated PathSegment
         /// </summary>
         /// <param name="pathType"></param>
         /// <param name="track"></param>
         /// <param name="obj"></param>
-        public static void AlignPrev(GFZPathType pathType, GfzTrack track, GameObject obj)
+        public static void AlignPrev(PathType pathType, GfzTrack track, GameObject obj)
         {
             // Get last of GfzPathSegment
             GfzPathSegment prev = track.AllRoots[track.AllRoots.Length - 2];
@@ -92,7 +100,8 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
 
             switch (pathType)
             {
-                case GFZPathType.BEZIER_OLD:
+                case PathType.BezierOld:
+                    Undo.RecordObject(obj, $"Change Bezier {obj.name}");
                     GfzPathBezier bezier = obj.GetComponent<GfzPathBezier>();
                     // ControlPoint0
                     BezierPoint controlPoint = bezier.GetBezierPoint(0);
@@ -107,13 +116,13 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
                     controlPoint.roll = matrix.RotationEuler().z;
                     bezier.SetBezierPoint(1, controlPoint);
                     break;
-                case GFZPathType.BEZIER:
+                case PathType.Bezier:
                     Undo.RecordObject(obj, $"Change FixedBezier {obj.name}");
                     GfzPathFixedBezier fixedBezier = obj.GetComponent<GfzPathFixedBezier>();
                     fixedBezier.SetControlPoints(matrix.Position(), matrix.rotation);
                     break;
-                case GFZPathType.LINE:
-                case GFZPathType.SPIRAL:
+                case PathType.Line:
+                case PathType.Spiral:
                     Undo.RecordObject(obj, $"Change Transform {obj.name}");
                     obj.transform.position = matrix.Position();
                     obj.transform.rotation = matrix.rotation;
@@ -125,21 +134,21 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         }
 
         /// <summary>
-        /// Add GfzShape Component
+        /// Add GfzShape component
         /// </summary>
         /// <param name="roadType"></param>
         /// <param name="obj"></param>
-        public static void AddGfzShape(GFZRoadType roadType, GameObject obj)
+        public static void AddGfzShape(RoadType roadType, GameObject obj)
         {
             switch (roadType)
             {
-                case GFZRoadType.NORMAL:
+                case RoadType.Normal:
                     Undo.AddComponent<GfzShapeRoad>(obj);
                     break;
-                case GFZRoadType.CIRCLE:
+                case RoadType.CylinderPipe:
                     Undo.AddComponent<GfzShapePipeCylinder>(obj);
                     break;
-                case GFZRoadType.CAPSULE:
+                case RoadType.Capsule:
                     Undo.AddComponent<GfzShapeCapsule>(obj);
                     break;
             }
@@ -147,11 +156,11 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         }
 
         /// <summary>
-        /// Generate GfzPathSegment Extended Component as child
+        /// Generate GfzPathSegment extended component as child
         /// </summary>
         /// <param name="pathType"></param>
         /// <param name="roadType"></param>
-        public static void GenerateGfzPath(GFZPathType pathType, GFZRoadType roadType)
+        public static void GenerateGfzPath(PathType pathType, RoadType roadType)
         {
             int idx = -1;
             GfzTrack track;
@@ -177,19 +186,19 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
             string pathName = "";
             switch (pathType)
             {
-                case GFZPathType.BEZIER_OLD:
-                case GFZPathType.BEZIER:
+                case PathType.BezierOld:
+                case PathType.Bezier:
                     GfzPathFixedBezier[] gfzPathFixedBeziers = GameObject.FindObjectsOfType<GfzPathFixedBezier>();
                     GfzPathBezier[] gfzPathBeziers = GameObject.FindObjectsOfType<GfzPathBezier>();
                     idx = gfzPathFixedBeziers.Length + gfzPathBeziers.Length;
                     pathName = $"{NamePathBezier} ({idx})";
                     break;
-                case GFZPathType.LINE:
+                case PathType.Line:
                     GfzPathLine[] gfzPathLines = GameObject.FindObjectsOfType<GfzPathLine>();
                     idx = gfzPathLines.Length;
                     pathName = $"{NamePathLine} ({idx})";
                     break;
-                case GFZPathType.SPIRAL:
+                case PathType.Spiral:
                     GfzPathSpiral[] gfzPathSpirals = GameObject.FindObjectsOfType<GfzPathSpiral>();
                     idx = gfzPathSpirals.Length;
                     pathName = $"{NamePathSpiral} ({idx})";
@@ -200,13 +209,13 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
             string roadName = "";
             switch (roadType)
             {
-                case GFZRoadType.NORMAL:
+                case RoadType.Normal:
                     roadName = NameRoadNormal;
                     break;
-                case GFZRoadType.CIRCLE:
+                case RoadType.CylinderPipe:
                     roadName = NameRoadCylindePipe;
                     break;
-                case GFZRoadType.CAPSULE:
+                case RoadType.Capsule:
                     roadName = NameRoadCupsule;
                     break;
             }
@@ -231,44 +240,44 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
 
         // Normal Road
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
-        public static void AddPathBezierNormalRoad() => GenerateGfzPath(GFZPathType.BEZIER, GFZRoadType.NORMAL);
+        public static void AddPathBezierNormalRoad() => GenerateGfzPath(PathType.Bezier, RoadType.Normal);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
-        public static void AddPathLineNormalRoad() => GenerateGfzPath(GFZPathType.LINE, GFZRoadType.NORMAL);
+        public static void AddPathLineNormalRoad() => GenerateGfzPath(PathType.Line, RoadType.Normal);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
-        public static void AddPathSprialNormalRoad() => GenerateGfzPath(GFZPathType.SPIRAL, GFZRoadType.NORMAL);
+        public static void AddPathSprialNormalRoad() => GenerateGfzPath(PathType.Spiral, RoadType.Normal);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
-        public static void AddPathBezierOldNormalRoad() => GenerateGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.NORMAL);
+        public static void AddPathBezierOldNormalRoad() => GenerateGfzPath(PathType.BezierOld, RoadType.Normal);
 
 
-        // Circle Road
-        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
-        public static void AddPathBezierCircleRoad() => GenerateGfzPath(GFZPathType.BEZIER, GFZRoadType.CIRCLE);
+        // CylinderPipe Road
+        [MenuItem(GfzMenuItems.TrackCreate.AddCylinderPipeRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
+        public static void AddPathBezierCylinderPipeRoad() => GenerateGfzPath(PathType.Bezier, RoadType.CylinderPipe);
 
-        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
-        public static void AddPathLineCircleRoad() => GenerateGfzPath(GFZPathType.LINE, GFZRoadType.CIRCLE);
+        [MenuItem(GfzMenuItems.TrackCreate.AddCylinderPipeRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
+        public static void AddPathLineCylinderPipeRoad() => GenerateGfzPath(PathType.Line, RoadType.CylinderPipe);
 
-        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
-        public static void AddPathSprialCircleRoad() => GenerateGfzPath(GFZPathType.SPIRAL, GFZRoadType.CIRCLE);
+        [MenuItem(GfzMenuItems.TrackCreate.AddCylinderPipeRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
+        public static void AddPathSprialCylinderPipeRoad() => GenerateGfzPath(PathType.Spiral, RoadType.CylinderPipe);
 
-        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
-        public static void AddPathBezierOldCircleRoad() => GenerateGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CIRCLE);
+        [MenuItem(GfzMenuItems.TrackCreate.AddCylinderPipeRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
+        public static void AddPathBezierOldCylinderPipeRoad() => GenerateGfzPath(PathType.BezierOld, RoadType.CylinderPipe);
 
 
         // Capsule Road
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
-        public static void AddPathBezierCapsuleRoad() => GenerateGfzPath(GFZPathType.BEZIER, GFZRoadType.CAPSULE);
+        public static void AddPathBezierCapsuleRoad() => GenerateGfzPath(PathType.Bezier, RoadType.Capsule);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
-        public static void AddPathLineCapsuleRoad() => GenerateGfzPath(GFZPathType.LINE, GFZRoadType.CAPSULE);
+        public static void AddPathLineCapsuleRoad() => GenerateGfzPath(PathType.Line, RoadType.Capsule);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
-        public static void AddPathSprialCapsuleRoad() => GenerateGfzPath(GFZPathType.SPIRAL, GFZRoadType.CAPSULE);
+        public static void AddPathSprialCapsuleRoad() => GenerateGfzPath(PathType.Spiral, RoadType.Capsule);
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
-        public static void AddPathBezierOldCapsuleRoad() => GenerateGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CAPSULE);
+        public static void AddPathBezierOldCapsuleRoad() => GenerateGfzPath(PathType.BezierOld, RoadType.Capsule);
 
     }
 }

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -136,19 +136,11 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
             {
                 track.RefreshSegmentNodes();
                 GfzPathSegment last = track.AllRoots[track.AllRoots.Length - 1];
-                AnimationCurveTRS trs = last.CopyAnimationCurveTRS(false);
-
-                Vector3 pos = new Vector3(
-                    trs.Position.x[trs.Position.x.length -1].value,
-                    trs.Position.y[trs.Position.y.length -1].value,
-                    trs.Position.z[trs.Position.z.length -1].value);
-                pathSegment.transform.position = pos;
-
-                Quaternion q = Quaternion.Euler(
-                    trs.Rotation.x[trs.Rotation.x.length - 1].value,
-                    trs.Rotation.y[trs.Rotation.y.length - 1].value,
-                    trs.Rotation.z[trs.Rotation.z.length - 1].value);
-                pathSegment.transform.rotation = q;
+                var hacTRS = last.CreateHierarchichalAnimationCurveTRS(false);
+                float maxTime = hacTRS.GetMaxTime();
+                var matrix = hacTRS.AnimationCurveTRS.EvaluateMatrix(maxTime);
+                pathSegment.transform.position = matrix.Position();
+                pathSegment.transform.rotation = matrix.rotation;
 
             }
 

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -22,7 +22,9 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
     {
         Normal,
         CylinderPipe,
-        Capsule
+        Capsule,
+        OpenPipeCylinder,
+        SquareCorner
     }
 
     public static class TrackCreateMenuItems
@@ -34,6 +36,8 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
         const string NameRoadNormal = "road";
         const string NameRoadCylindePipe = "circle";
         const string NameRoadCupsule = "capsule";
+        const string NameRoadOpenPipeCylinder = "opencircle";
+        const string NameRoadSquareCorner = "square";
 
         /// <summary>
         ///  Generate GfzTrack component
@@ -143,6 +147,12 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
                 case RoadType.Capsule:
                     Undo.AddComponent<GfzShapeCapsule>(obj);
                     break;
+                case RoadType.OpenPipeCylinder:
+                    Undo.AddComponent<GfzShapeOpenPipeCylinder>(obj);
+                    break;
+                case RoadType.SquareCorner:
+                    Undo.AddComponent<GfzShapeSquareCorner>(obj);
+                    break;
             }
 
         }
@@ -210,6 +220,12 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
                 case RoadType.Capsule:
                     roadName = NameRoadCupsule;
                     break;
+                case RoadType.OpenPipeCylinder:
+                    roadName = NameRoadOpenPipeCylinder;
+                    break;
+                case RoadType.SquareCorner:
+                    roadName = NameRoadSquareCorner;
+                    break;
             }
             GameObject roadShape = new GameObject(roadName);
             roadShape.transform.parent = pathSegment.transform;
@@ -270,6 +286,19 @@ namespace Manifold.EditorTools.GC.GFZ.Stage.Track
 
         [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
         public static void AddPathBezierOldCapsuleRoad() => GenerateGfzPath(PathType.BezierOld, RoadType.Capsule);
+
+        // OpenPipeCylinder Road
+        [MenuItem(GfzMenuItems.TrackCreate.AddOpenPipeCylinderRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
+        public static void AddPathBezierOpenPipeCylinderRoad() => GenerateGfzPath(PathType.Bezier, RoadType.OpenPipeCylinder);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddOpenPipeCylinderRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
+        public static void AddPathLineOpenPipeCylinderRoad() => GenerateGfzPath(PathType.Line, RoadType.OpenPipeCylinder);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddOpenPipeCylinderRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
+        public static void AddPathSprialOpenPipeCylinderRoad() => GenerateGfzPath(PathType.Spiral, RoadType.OpenPipeCylinder);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddOpenPipeCylinderRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
+        public static void AddPathBezierOldOpenPipeCylinderRoad() => GenerateGfzPath(PathType.BezierOld, RoadType.OpenPipeCylinder);
 
     }
 }

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs
@@ -1,0 +1,193 @@
+﻿using GameCube.GFZ.TPL;
+using Manifold.IO;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+namespace Manifold.EditorTools.GC.GFZ.Stage.Track
+{
+    public enum GFZPathType
+    {
+        BEZIER_OLD,
+        BEZIER,
+        LINE,
+        SPIRAL
+    }
+
+    public enum GFZRoadType
+    {
+        NORMAL,
+        CIRCLE,
+        CAPSULE
+    }
+
+    public static class TrackCreateMenuItems
+    {
+
+        /// <summary>
+        /// Add GfzTrack Component as child.
+        /// </summary>
+        [MenuItem(GfzMenuItems.TrackCreate.AddTrack, priority = 1)]
+        public static void AddTrack()
+        {
+            GameObject track = new GameObject("Track");
+            //Undo.RegisterCreatedObjectUndo(track, "Add Track");
+
+            track.AddComponent<GfzTrack>();
+
+            return;
+        }
+
+        // Add GfzShape Component as child.
+        public static void AddGfzShape(Transform parent, GFZRoadType roadType)
+        {
+            string objName = "";
+            switch (roadType)
+            {
+                case GFZRoadType.NORMAL:
+                    objName = "road";
+                    break;
+                case GFZRoadType.CIRCLE:
+                    objName = "circle";
+                    break;
+                case GFZRoadType.CAPSULE:
+                    objName = "capsule";
+                    break;
+            }
+
+            GameObject obj = new GameObject(objName);
+            //Undo.RegisterCreatedObjectUndo(obj, $"Add {objName}");
+            //EditorUtility.SetDirty(obj);
+
+            obj.transform.parent = parent;
+
+            switch (roadType)
+            {
+                case GFZRoadType.NORMAL:
+                    obj.AddComponent<GfzShapeRoad>();
+                    break;
+                case GFZRoadType.CIRCLE:
+                    obj.AddComponent<GfzShapePipeCylinder>();
+                    break;
+                case GFZRoadType.CAPSULE:
+                    obj.AddComponent<GfzShapeCapsule>();
+                    break;
+            }
+
+        }
+
+        // Add GfzPathSegment Component as child.
+        public static void AddGfzPath(GFZPathType pathType, GFZRoadType roadType)
+        {
+            int idx = -1; // TODO: GET index
+
+            GameObject track = GameObject.FindObjectOfType<GfzTrack>().gameObject;
+
+            if (track == null)
+            {
+                return;
+            }
+
+
+            string objName = "";
+            switch (pathType)
+            {
+                case GFZPathType.BEZIER_OLD:
+                case GFZPathType.BEZIER:
+                    GfzPathFixedBezier[] gfzPathFixedBeziers = GameObject.FindObjectsOfType<GfzPathFixedBezier>();
+                    GfzPathBezier[] gfzPathBeziers = GameObject.FindObjectsOfType<GfzPathBezier>();
+                    idx = gfzPathFixedBeziers.Length + gfzPathBeziers.Length;
+                    objName = $"bezier ({idx})";
+                    break;
+                case GFZPathType.LINE:
+                    GfzPathLine[] gfzPathLines = GameObject.FindObjectsOfType<GfzPathLine>();
+                    idx = gfzPathLines.Length;
+                    objName = $"ilne ({idx})";
+                    break;
+                case GFZPathType.SPIRAL:
+                    GfzPathSpiral[] gfzPathSpirals = GameObject.FindObjectsOfType<GfzPathSpiral>();
+                    idx = gfzPathSpirals.Length;
+                    objName = $"spiral ({idx})";
+                    break;
+            }
+
+
+            GameObject obj = new GameObject(objName);
+            //Undo.RegisterCreatedObjectUndo(obj, $"Add Path");
+            //EditorUtility.SetDirty(obj);
+
+            //Undo.RecordObject(track, $"set {objName} as child of Track");
+            obj.transform.parent = track.transform;
+            //EditorUtility.SetDirty(track);
+
+            //Undo.RecordObject(track, $"AddComponent {pathType}");
+            switch (pathType)
+            {
+                case GFZPathType.BEZIER_OLD:
+                    obj.AddComponent<GfzPathBezier>();
+                    break;
+                case GFZPathType.BEZIER:
+                    obj.AddComponent<GfzPathFixedBezier>();
+                    break;
+                case GFZPathType.LINE:
+                    obj.AddComponent<GfzPathLine>();
+                    break;
+                case GFZPathType.SPIRAL:
+                    obj.AddComponent<GfzPathSpiral>();
+                    break;
+            }
+
+
+            AddGfzShape(obj.transform, roadType);
+
+            //EditorUtility.SetDirty(track);
+
+            return;
+        }
+
+        // Normal Road
+        [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
+        public static void AddPathBezierNormalRoad() => AddGfzPath(GFZPathType.BEZIER, GFZRoadType.NORMAL);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
+        public static void AddPathLineNormalRoad() => AddGfzPath(GFZPathType.LINE, GFZRoadType.NORMAL);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
+        public static void AddPathSprialNormalRoad() => AddGfzPath(GFZPathType.SPIRAL, GFZRoadType.NORMAL);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddNormalRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
+        public static void AddPathBezierOldNormalRoad() => AddGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.NORMAL);
+
+
+        // Circle Road
+        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
+        public static void AddPathBezierCircleRoad() => AddGfzPath(GFZPathType.BEZIER, GFZRoadType.CIRCLE);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
+        public static void AddPathLineCircleRoad() => AddGfzPath(GFZPathType.LINE, GFZRoadType.CIRCLE);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
+        public static void AddPathSprialCircleRoad() => AddGfzPath(GFZPathType.SPIRAL, GFZRoadType.CIRCLE);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddCircleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
+        public static void AddPathBezierOldCircleRoad() => AddGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CIRCLE);
+
+
+        // Capsule Road
+        [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezier, priority = 100)]
+        public static void AddPathBezierCapsuleRoad() => AddGfzPath(GFZPathType.BEZIER, GFZRoadType.CAPSULE);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddLine, priority = 101)]
+        public static void AddPathLineCapsuleRoad() => AddGfzPath(GFZPathType.LINE, GFZRoadType.CAPSULE);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddSpiral, priority = 102)]
+        public static void AddPathSprialCapsuleRoad() => AddGfzPath(GFZPathType.SPIRAL, GFZRoadType.CAPSULE);
+
+        [MenuItem(GfzMenuItems.TrackCreate.AddCapsuleRoad + GfzMenuItems.TrackCreate.AddBezierOld, priority = 999)]
+        public static void AddPathBezierOldCapsuleRoad() => AddGfzPath(GFZPathType.BEZIER_OLD, GFZRoadType.CAPSULE);
+
+    }
+}

--- a/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs.meta
+++ b/Manifold_Unity/Assets/Root/Manifold/EditorTools/GC/GFZ/Stage/Track/TrackCreateMenuItems.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd844a054f469fc45a498f8719ede5b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This request add Track Create utility menu.
![image](https://user-images.githubusercontent.com/34136940/188745593-67eaf1ba-d297-4adb-9b9b-eeab8e132229.png)

Current users needs prepare GfzTrack. 
And adding GfzPathBezier, GfzPathLine, GfzPathSpiral, GfzPathFixedBezier.
I thinks it's not familial for user. (Especially non experience about Unity user.)
After merge users prepare tracks from this menu.

Also objects what generate by this menu are align to last of GfzPathSegment.